### PR TITLE
Port of cobot-login to Mac OS X

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # cobot-login
 
-This script logs you into [cobot][]'s captive portal. It's sort of like [Alexis][alex]' script (for MacOSX), but for Ubuntu.
+This script logs you into [cobot][]'s captive portal. It's sort of like [Alexis][alexis]' script (for Mac OS X), but for Ubuntu.
 
-[alex]: http://twitter.com/surryhill
+[alexis]: http://github.com/afh/
 [cobot]: http://cobot.me
 
 # Todo

--- a/etc/space.cfg-dist
+++ b/etc/space.cfg-dist
@@ -11,3 +11,4 @@
 #
 
 cobot_space_name='co-up'
+cobot_space_ssids="co_up_n co_up_bg"

--- a/etc/user.cfg-dist
+++ b/etc/user.cfg-dist
@@ -1,3 +1,3 @@
 #!/bin/sh
-cobot_username=`whoami`
+cobot_username=${USER}
 cobot_pass="yourpass"

--- a/functions
+++ b/functions
@@ -1,24 +1,38 @@
 #!/usr/bin/env bash
 
-# generateFullCobotUsername name space
+# generate full cobot username as required by captive portal login
 getFullCobotUsername () {
+    local cobot_user_name="${1}"
+    local cobot_space_name="${2}"
     local cobot_account_type='user'
-    local cobot_username_postfix="%40${cobot_account_type}.${2}"
+    local cobot_username_suffix="%40${cobot_account_type}.${cobot_space_name}"
 
-    echo "${1}${cobot_username_postfix}"
+    echo "${cobot_username}${cobot_username_suffix}"
 }
 
-# work in progress
-findPasswordInKeyChain () {
-    local pass=$(security find-generic-password -l ${keychain_item_name} -g ${keychaing_name} 2>&1 | grep 'password:' sed -e 's/password: "\(.*\)"/\1/' | tr -d "\n")
-    echo "${pass}"
+# return a password from the Mac OS X keychain
+# TODO: Improve keychain search for generic and internet passwords
+#       e.g. by adding support for account, label, and server matching
+getPasswordFromKeychain () {
+    local keychain_item_name="${1}"
+    local keychain_name="${2}"
+    local pass=$(security find-generic-password -l ${keychain_item_name} -g ${keychain_name} 2>&1 \
+      | sed -e '2,$d' -e 's/password: \"\(.*\)\"/\1/' \
+      | tr -d \"\n\")
+
+    echo -n "${pass}"
+}
+
+# return the password from the user.cfg
+getPasswordFromUserCfg () {
+    echo -n "${cobot_pass}"
 }
 
 # discover the captive portal's url
 discoverCaptivePortal () {
     local url=$(curl -w=%{redirect_url} -o /dev/null -s -I http://www.google.de/)
 
-    if [ "$url" = "=" ]; then
+    if [ "${url}" = "=" ]; then
         echo ""
     fi
 

--- a/if.up/cobot
+++ b/if.up/cobot
@@ -10,29 +10,72 @@ PATH=/sbin:/bin:/usr/sbin:/usr/bin:/usr/local/bin
 
 #
 # HowTo:
-# * this is for ubuntu
-# * sudo ln -s /path/to/if.up/cobot /etc/network/if-up.d/cobot
+# * All:
+#   - edit cobot_login variable below to match your cobot-login installation
+#     path
 #
+# * Unbuntu:
+#   - sudo ln -s /path/to/if.up/cobot /etc/network/if-up.d/cobot
+#
+# * Darwin:
+#   - edit the CobotLogin variable in sentinel.rb to match your cobot-login
+#     installation path
+#   - run sentinel.rb from cobot-login
+#
+
+system_name=`uname -s`
+if [ "Darwin" = "${system_name}" ]; then
+notify-send() {
+  # shift off unsupported urgency level parameters
+  shift; shift
+  # TODO: check for growl or cmessage and default to osascript
+  osascript -e 'tell application "Finder"' \
+    -e "activate" \
+    -e "display dialog \"$*\"" \
+    -e 'end tell'  >/dev/null 2>&1 &
+}
+fi
 
 notify-send -u normal "OHAI"
 
-if [ `uname -s` != "Linux" ]; then
-    echo "You are not on Linux."
+case ${system_name} in
+  Linux|*BSD)
+    ssid=`iwconfig wlan0 | grep ESSID | cut -d '"' -f 2`
+  ;;
+
+  Darwin)
+    # this requires knowledge of the network device name, e.g. en1...
+    #ssid=$(networksetup -getairportnetwork en1 | cut -d: -f 2 | tr -d ' ')
+    # ... this doesn't ;)
+    ssid=$(/System/Library/PrivateFrameworks/Apple80211.framework/Versions/Current/Resources/airport -I | grep '[^B]SSID' | cut -d: -f 2 | tr -d ' ')
+  ;;
+
+  *)
+    notify-send -u critical "The ${system_name} operating system is not supported"
     exit 1
-fi
+  ;;
+esac
 
-ssid=`iwconfig wlan0 | grep ESSID | cut -d '"' -f 2`
+#login_script="$(readlink -f $(dirname ${0}))/../login.sh"
+#login_script=$(readlink -f ${login_script})
 
-#login_script="$(readlink -f $(dirname $0))/../login.sh"
-#login_script=$(readlink -f $login_script)
+cobot_login="${HOME}/bin/cobot-login"
+login_script="${cobot_login}/login.sh"
+space_config="${cobot_login}/etc/space.cfg"
+source ${space_config}
 
-login_script="/home/till/cobot-login/login.sh"
+in_space=0
+for space_ssid in ${cobot_space_ssids}; do
+  [ "${ssid}" = "${space_ssid}" ] && in_space=1
+done
 
-if [ "$ssid" = "co_up_n" -o "$ssid" = "co_up_bg" ]; then
-    $login_script
+if [ ${in_space} -eq 1 ]; then
+    ${login_script}
     if [ "$?" -ne "0" ]; then
         notify-send -u critical "Couldn't log you in."
     else
         notify-send -u normal "Captive portal login worked!"
     fi
+else
+    notify-send -u normal "It seems you are not at a known coworking space."
 fi

--- a/sentinel.rb
+++ b/sentinel.rb
@@ -1,0 +1,82 @@
+#!/usr/bin/env ruby
+#
+# sentinel.rb - run cobot-login script on AirPort state change
+#
+
+CobotLogin="${HOME}/bin/cobot-login"
+
+def find_airport_interfaces()
+  interfaces = []
+  list = `echo list | scutil`
+  list.each do |line|
+    next unless (line =~ /State.*AirPort$/)
+    interface = line.split(' = ')[1]
+    interfaces << interface
+  end
+  return interfaces
+end
+
+def is_connected(interface, f)
+  power_status = false
+  busy_status = false
+  ssid_match = false
+
+  f.puts("get #{interface}")
+  f.puts("d.show")
+  while (line = f.gets()) do
+    return false if line =~ /^\}$/
+    # run cobot-login script if AirPort is powered up
+    # and initialisation is finished
+    power_status = true if line =~ /Power Status : 1/
+    busy_status = true if line =~ /Busy : FALSE/
+    ssid_match = true if line =~ /SSID_STR : \w+/
+    if (power_status && busy_status && ssid_match) then
+      return true
+    end
+  end
+  return false
+end
+
+def run()
+  interfaces = find_airport_interfaces()
+  if interfaces.empty? then
+    puts "No AirPort interfaces found"
+    exit
+  end
+
+  IO.popen("scutil", "w+") do |f|
+    # watch all AirPort interfaces
+    interfaces.each do |interface|
+      puts "Monitoring #{interface}"
+      f.puts("n.add #{interface}")
+      f.puts("n.watch")
+    end
+
+    # wait for AirPort State change
+    while (line = f.gets()) do
+      next unless line =~ /changed key/
+      interface = line.split(' = ')[1]
+      # get the changed data
+      if is_connected(interface, f) then
+        # sleep a little while until an ip address has been obtained via DHCP
+        # monitoring the interface link is probably be more accurate
+        #link = interface.gsub(/AirPort$/, 'Link')
+        sleep 5
+        puts "running cobot login"
+        system("#{CobotLogin}/if.up/cobot")
+      end
+    end
+  end
+end
+
+
+if '-f' == ARGV[0]
+  # run in foreground
+  run
+else
+  # daemonize
+  pid = fork  do
+    run
+  end
+  Process.detach(pid)
+end


### PR DESCRIPTION
The commit includes several cleanup changes and adds Mac OS X support by retrieving the cobot login password form the Keychain and watching AirPort state changes to run the cobot-login script if necessary.
